### PR TITLE
[Fix] TIME_BLOCK scope issue

### DIFF
--- a/time_block.h
+++ b/time_block.h
@@ -1,43 +1,47 @@
+#ifndef TIME_BLOCK_H
+#define TIME_BLOCK_H
+
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
 
+static clock_t start_time;
+static clock_t end_time;
+static double time_taken;
+
 // Available units: ns, us, ms, s, m, h; Leave empty for dynamic scaling
 #define TIME_BLOCK(label, unit, code_block)                                    \
-  do {                                                                         \
-    clock_t start_time = clock();                                              \
-    code_block;                                                                \
-    clock_t end_time = clock();                                                \
-    double time_taken = ((double)(end_time - start_time)) / CLOCKS_PER_SEC;    \
-    if (unit && strcmp(unit, "ns") == 0) {                                     \
+  start_time = clock();                                                        \
+  code_block;                                                                  \
+  end_time = clock();                                                          \
+  time_taken = ((double)(end_time - start_time)) / CLOCKS_PER_SEC;             \
+  if (unit && strcmp(unit, "ns") == 0) {                                       \
+    printf("[%s] Time taken: %.3f nanoseconds\n", label, time_taken * 1e9);    \
+  } else if (unit && strcmp(unit, "us") == 0) {                                \
+    printf("[%s] Time taken: %.3f microseconds\n", label, time_taken * 1e6);   \
+  } else if (unit && strcmp(unit, "ms") == 0) {                                \
+    printf("[%s] Time taken: %.3f milliseconds\n", label, time_taken * 1e3);   \
+  } else if (unit && strcmp(unit, "s") == 0) {                                 \
+    printf("[%s] Time taken: %.3f seconds\n", label, time_taken);              \
+  } else if (unit && strcmp(unit, "m") == 0) {                                 \
+    printf("[%s] Time taken: %.3f minutes\n", label, time_taken / 60);         \
+  } else if (unit && strcmp(unit, "h") == 0) {                                 \
+    printf("[%s] Time taken: %.3f hours\n", label, time_taken / 3600);         \
+  } else {                                                                     \
+    /* Dynamic scaling if no valid unit is specified */                        \
+    if (time_taken < 1e-6) {                                                   \
       printf("[%s] Time taken: %.3f nanoseconds\n", label, time_taken * 1e9);  \
-    } else if (unit && strcmp(unit, "us") == 0) {                              \
+    } else if (time_taken < 1e-3) {                                            \
       printf("[%s] Time taken: %.3f microseconds\n", label, time_taken * 1e6); \
-    } else if (unit && strcmp(unit, "ms") == 0) {                              \
+    } else if (time_taken < 1) {                                               \
       printf("[%s] Time taken: %.3f milliseconds\n", label, time_taken * 1e3); \
-    } else if (unit && strcmp(unit, "s") == 0) {                               \
+    } else if (time_taken < 60) {                                              \
       printf("[%s] Time taken: %.3f seconds\n", label, time_taken);            \
-    } else if (unit && strcmp(unit, "m") == 0) {                               \
+    } else if (time_taken < 3600) {                                            \
       printf("[%s] Time taken: %.3f minutes\n", label, time_taken / 60);       \
-    } else if (unit && strcmp(unit, "h") == 0) {                               \
-      printf("[%s] Time taken: %.3f hours\n", label, time_taken / 3600);       \
     } else {                                                                   \
-      /* Dynamic scaling if no valid unit is specified */                      \
-      if (time_taken < 1e-6) {                                                 \
-        printf("[%s] Time taken: %.3f nanoseconds\n", label,                   \
-               time_taken * 1e9);                                              \
-      } else if (time_taken < 1e-3) {                                          \
-        printf("[%s] Time taken: %.3f microseconds\n", label,                  \
-               time_taken * 1e6);                                              \
-      } else if (time_taken < 1) {                                             \
-        printf("[%s] Time taken: %.3f milliseconds\n", label,                  \
-               time_taken * 1e3);                                              \
-      } else if (time_taken < 60) {                                            \
-        printf("[%s] Time taken: %.3f seconds\n", label, time_taken);          \
-      } else if (time_taken < 3600) {                                          \
-        printf("[%s] Time taken: %.3f minutes\n", label, time_taken / 60);     \
-      } else {                                                                 \
-        printf("[%s] Time taken: %.3f hours\n", label, time_taken / 3600);     \
-      }                                                                        \
+      printf("[%s] Time taken: %.3f hours\n", label, time_taken / 3600);       \
     }                                                                          \
-  } while (0)
+  }
+
+#endif // !TIME_BLOCK_H

--- a/time_block.h
+++ b/time_block.h
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <time.h>
 
+// Available units: ns, us, ms, s, m, h; Leave empty for dynamic scaling
 #define TIME_BLOCK(label, unit, code_block)                                    \
   {                                                                            \
     clock_t start_time = clock();                                              \

--- a/time_block.h
+++ b/time_block.h
@@ -5,42 +5,44 @@
 #include <string.h>
 #include <time.h>
 
-static clock_t start_time;
-static clock_t end_time;
-static double time_taken;
-
-// Available units: ns, us, ms, s, m, h; Leave empty for dynamic scaling
 #define TIME_BLOCK(label, unit, code_block)                                    \
-  start_time = clock();                                                        \
-  code_block;                                                                  \
-  end_time = clock();                                                          \
-  time_taken = ((double)(end_time - start_time)) / CLOCKS_PER_SEC;             \
-  if (unit && strcmp(unit, "ns") == 0) {                                       \
-    printf("[%s] Time taken: %.3f nanoseconds\n", label, time_taken * 1e9);    \
-  } else if (unit && strcmp(unit, "us") == 0) {                                \
-    printf("[%s] Time taken: %.3f microseconds\n", label, time_taken * 1e6);   \
-  } else if (unit && strcmp(unit, "ms") == 0) {                                \
-    printf("[%s] Time taken: %.3f milliseconds\n", label, time_taken * 1e3);   \
-  } else if (unit && strcmp(unit, "s") == 0) {                                 \
-    printf("[%s] Time taken: %.3f seconds\n", label, time_taken);              \
-  } else if (unit && strcmp(unit, "m") == 0) {                                 \
-    printf("[%s] Time taken: %.3f minutes\n", label, time_taken / 60);         \
-  } else if (unit && strcmp(unit, "h") == 0) {                                 \
-    printf("[%s] Time taken: %.3f hours\n", label, time_taken / 3600);         \
-  } else {                                                                     \
-    /* Dynamic scaling if no valid unit is specified */                        \
-    if (time_taken < 1e-6) {                                                   \
+  {                                                                            \
+    clock_t start_time = clock();                                              \
+    {                                                                          \
+      code_block;                                                              \
+    }                                                                          \
+    clock_t end_time = clock();                                                \
+    double time_taken = ((double)(end_time - start_time)) / CLOCKS_PER_SEC;    \
+    if (unit && strcmp(unit, "ns") == 0) {                                     \
       printf("[%s] Time taken: %.3f nanoseconds\n", label, time_taken * 1e9);  \
-    } else if (time_taken < 1e-3) {                                            \
+    } else if (unit && strcmp(unit, "us") == 0) {                              \
       printf("[%s] Time taken: %.3f microseconds\n", label, time_taken * 1e6); \
-    } else if (time_taken < 1) {                                               \
+    } else if (unit && strcmp(unit, "ms") == 0) {                              \
       printf("[%s] Time taken: %.3f milliseconds\n", label, time_taken * 1e3); \
-    } else if (time_taken < 60) {                                              \
+    } else if (unit && strcmp(unit, "s") == 0) {                               \
       printf("[%s] Time taken: %.3f seconds\n", label, time_taken);            \
-    } else if (time_taken < 3600) {                                            \
+    } else if (unit && strcmp(unit, "m") == 0) {                               \
       printf("[%s] Time taken: %.3f minutes\n", label, time_taken / 60);       \
-    } else {                                                                   \
+    } else if (unit && strcmp(unit, "h") == 0) {                               \
       printf("[%s] Time taken: %.3f hours\n", label, time_taken / 3600);       \
+    } else {                                                                   \
+      /* Dynamic scaling if no valid unit is specified */                      \
+      if (time_taken < 1e-6) {                                                 \
+        printf("[%s] Time taken: %.3f nanoseconds\n", label,                   \
+               time_taken * 1e9);                                              \
+      } else if (time_taken < 1e-3) {                                          \
+        printf("[%s] Time taken: %.3f microseconds\n", label,                  \
+               time_taken * 1e6);                                              \
+      } else if (time_taken < 1) {                                             \
+        printf("[%s] Time taken: %.3f milliseconds\n", label,                  \
+               time_taken * 1e3);                                              \
+      } else if (time_taken < 60) {                                            \
+        printf("[%s] Time taken: %.3f seconds\n", label, time_taken);          \
+      } else if (time_taken < 3600) {                                          \
+        printf("[%s] Time taken: %.3f minutes\n", label, time_taken / 60);     \
+      } else {                                                                 \
+        printf("[%s] Time taken: %.3f hours\n", label, time_taken / 3600);     \
+      }                                                                        \
     }                                                                          \
   }
 

--- a/time_block_example.c
+++ b/time_block_example.c
@@ -34,10 +34,10 @@ int main() {
   TIME_BLOCK("Dynamic Fibonacci sequence for 1000", "ns",
              dynamicFibonacci(1000));
 
-  TIME_BLOCK("Defined variables can be used outside the scope now", "",
-             int i = 20;
-             ++i;);
-  ++i;
+  // NOTE: If necessary to use variables outside the TIME_BLOCK afterwards
+  // define them outside first
+  int i = 20;
+  TIME_BLOCK("Use varibles outside the TIME_BLOCK", "", fibonacci(i); ++i;);
   printf("%d\n", i);
 
   return 0;

--- a/time_block_example.c
+++ b/time_block_example.c
@@ -1,7 +1,5 @@
 #include "time_block.h"
-#include <pthread.h>
-#include <stdbool.h>
-#include <unistd.h>
+
 long long fibonacci(int n) {
   if (n <= 1) {
     return n;
@@ -26,16 +24,21 @@ long long dynamicFibonacci(int n) {
 
 int main() {
   // Find out how long it takes to calculate the 10th Fibonacci number
-  TIME_BLOCK("Classic Fibonacci sequens of 40", "", { fibonacci(40); });
-  TIME_BLOCK("Classic Fibonacci sequens of 40", "", { fibonacci(40); });
+  TIME_BLOCK("Classic Fibonacci sequens of 40", "", fibonacci(40));
+  TIME_BLOCK("Classic Fibonacci sequens of 40", "", fibonacci(40));
 
-  TIME_BLOCK("Classic Fibonacci sequens of 41", "", { fibonacci(41); });
+  TIME_BLOCK("Classic Fibonacci sequens of 41", "", fibonacci(41));
 
-  TIME_BLOCK("Dynamic Fibonacci sequence for 40", "ns",
-             { dynamicFibonacci(40); });
+  TIME_BLOCK("Dynamic Fibonacci sequence for 40", "ns", dynamicFibonacci(40));
 
   TIME_BLOCK("Dynamic Fibonacci sequence for 1000", "ns",
-             { dynamicFibonacci(1000); });
+             dynamicFibonacci(1000));
+
+  TIME_BLOCK("Defined variables can be used outside the scope now", "",
+             int i = 20;
+             ++i;);
+  ++i;
+  printf("%d\n", i);
 
   return 0;
 }


### PR DESCRIPTION
# Quick overview
- variables inside the TIME_BLOCK can now be accessed outside of it
> [!NOTE]
>```c
>TIME_BLOCK("Defined variables can be used outside the scope now", "",
>             int i = 20;
>             ++i;);
>++i;
>printf("%d\n", i);
>```
>will now print `22` and does not throw an error when compiling with make

- added include guard to `time_block.h` just to be safe

## Detailed description of changes
- removed the do-while-loop and changed the variables to be defined static instead
Therefore the variables declared in the TIME_BLOCK can be used outside it afterwards